### PR TITLE
Use CSV format for data dumps

### DIFF
--- a/lib/capistrano/db_sync/postgres/cli.rb
+++ b/lib/capistrano/db_sync/postgres/cli.rb
@@ -41,12 +41,12 @@ class Capistrano::DBSync::Postgres::CLI
     SQL
   end
 
-  def copy_to_file(to_compressed_file, db, query)
-    psql "\\COPY (#{query}) TO PROGRAM 'gzip > #{to_compressed_file}'", db
+  def copy_and_compress_to_file(to_compressed_file, db, query)
+    psql "\\copy (#{query}) TO PROGRAM 'gzip > #{to_compressed_file}' WITH CSV", db
   end
 
-  def copy_from_file(from_compressed_file, db, table)
-    psql "\\COPY #{table} FROM PROGRAM 'gunzip --to-stdout #{from_compressed_file}'", db
+  def copy_from_compressed_file(from_compressed_file, db, table)
+    psql "\\copy #{table} FROM PROGRAM 'gunzip --to-stdout #{from_compressed_file}' WITH CSV", db
   end
 
   private

--- a/lib/capistrano/db_sync/postgres/exporter.rb
+++ b/lib/capistrano/db_sync/postgres/exporter.rb
@@ -52,7 +52,7 @@ module Capistrano::DBSync
 
     def dump_partial_selected_data(db, file_namer, data_selection)
       data_selection.map do |table, query|
-        cli.copy_to_file(file_namer.next(table, :table), db, query) if query
+        cli.copy_and_compress_to_file(file_namer.next(table, :table), db, query) if query
       end.compact
     end
 

--- a/lib/capistrano/db_sync/postgres/importer.rb
+++ b/lib/capistrano/db_sync/postgres/importer.rb
@@ -70,7 +70,7 @@ module Capistrano::DBSync
       files = Dir.glob(File.join(working_dir, "*.table"))
       files.map do |file|
         table_name = Postgres::FileNameGenerator.extract_name(file)
-        cli.copy_from_file(file, to_db, table_name)
+        cli.copy_from_compressed_file(file, to_db, table_name)
       end
     end
 

--- a/spec/lib/capistrano/db_sync/postgres/exporter_spec.rb
+++ b/spec/lib/capistrano/db_sync/postgres/exporter_spec.rb
@@ -8,9 +8,9 @@ describe Capistrano::DBSync::Postgres::Exporter do
   describe "#dump" do
     let(:data_selection) do
       {
-        campaigns:   "SELECT * FROM campaigns WHERE date > NOW() - interval '160 days'",
-        keywords:    "SELECT * FROM keywords  WHERE created_at > NOW() - interval '160 days'",
-        phone_calls: nil
+        posts:    "SELECT * FROM posts WHERE date > NOW() - interval '160 days'",
+        comments: "SELECT * FROM comments  WHERE created_at > NOW() - interval '160 days'",
+        likes: nil
       }
     end
 
@@ -19,13 +19,13 @@ describe Capistrano::DBSync::Postgres::Exporter do
 
       # Assert dumping database schema with data except for tables specified on data_selection
       commands[0].must_match /pg_dump.* -f \/tmp\/dumps\/0001-faceburger_production\.schema/
-      commands[0].must_match /--exclude-table-data="campaigns"/
-      commands[0].must_match /--exclude-table-data="keywords"/
-      commands[0].must_match /--exclude-table-data="phone_calls"/
+      commands[0].must_match /--exclude-table-data="posts"/
+      commands[0].must_match /--exclude-table-data="comments"/
+      commands[0].must_match /--exclude-table-data="likes"/
 
       # Assert dumping data for tables specified on data_selection
-      commands[1].must_match /COPY.*campaigns.*\/tmp\/dumps\/0002-campaigns\.table/
-      commands[2].must_match /COPY.*keywords.*\/tmp\/dumps\/0003-keywords\.table/
+      commands[1].must_match /copy.*posts.*\/tmp\/dumps\/0002-posts\.table/
+      commands[2].must_match /copy.*comments.*\/tmp\/dumps\/0003-comments\.table/
     end
   end
 end

--- a/spec/lib/capistrano/db_sync/postgres/importer_spec.rb
+++ b/spec/lib/capistrano/db_sync/postgres/importer_spec.rb
@@ -11,7 +11,7 @@ describe Capistrano::DBSync::Postgres::Importer do
         .returns(["/tmp/dumps/0001-faceburger_production.schema"])
 
       Dir.stubs(:glob).with("/tmp/dumps/*.table")
-        .returns(["/tmp/dumps/0002-campaigns.table", "/tmp/dumps/0003-keywords.table"])
+        .returns(["/tmp/dumps/0002-posts.table", "/tmp/dumps/0003-comments.table"])
     end
 
     it "restore dump files" do
@@ -27,8 +27,8 @@ describe Capistrano::DBSync::Postgres::Importer do
       commands[3].must_match /pg_restore.* \/tmp\/dumps\/0001-faceburger_production\.schema/
 
       # Assert import selective tables data
-      commands[4].must_match /COPY campaigns.*\/tmp\/dumps\/0002-campaigns\.table/
-      commands[5].must_match /COPY keywords.*\/tmp\/dumps\/0003-keywords\.table/
+      commands[4].must_match /copy posts.*\/tmp\/dumps\/0002-posts\.table/
+      commands[5].must_match /copy comments.*\/tmp\/dumps\/0003-comments\.table/
 
       # Assert restore indexes, constraints, triggers and rules
       commands[6].must_match /pg_restore.*--section=post-data --jobs=3/


### PR DESCRIPTION
- Using CSV format in PG copy commands
- Use \copy instead of \COPY to run the command on the client instead of
  server
- Rename copy_to and copy_from methods to reflect better what they
  really do (also compressing)