### PR TITLE
Use configurable temporary directories

### DIFF
--- a/lib/capistrano/db_sync/configuration.rb
+++ b/lib/capistrano/db_sync/configuration.rb
@@ -1,3 +1,4 @@
+require 'tmpdir'
 require 'active_support/core_ext/hash'
 
 module Capistrano::DBSync
@@ -21,14 +22,14 @@ module Capistrano::DBSync
 
           pg_jobs: 1, # Number of jobs to run in parallel on pg_restore
 
-          working_dir: "./tmp",
+          working_dir: Dir.tmpdir,
           env: ENV.fetch('RAILS_ENV', 'development'),
         },
 
         remote: {
           cleanup: true, # If the remote dump directory should be removed after downloaded
 
-          working_dir: "/tmp",
+          working_dir: cap.fetch(:tmp_dir, "/tmp"),
           env: cap.fetch(:stage).to_s,
         },
       }


### PR DESCRIPTION
Locally, `Dir.tmpdir` provides the idiomatic preferred directory
cf. http://ruby-doc.org/stdlib-2.2.1/libdoc/tmpdir/rdoc/Dir.html#method-c-tmpdir

Remotely, Capistrano provides a configurable setting
cf. https://github.com/capistrano/capistrano/blob/master/lib/capistrano/defaults.rb#L4